### PR TITLE
Run tests on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   tests-with-coverage:
-    name: Tests with coverage
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        os: ["windows-2019", "ubuntu-18.04"]
+    name: Tests (${{ matrix.os }}) with coverage
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
By default pipelines of plugins under the jenkinsci organization
are played on Linux and Windows. To avoid bad surprises when the repo
will be migrated we should execute the tests on both environnements.

This change is part of [community #14019](https://tuleap.net/plugins/tracker/?aid=14019)