### PR TITLE
Be able to be logged as a Tuleap user.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>3.0.1</version>

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapAuthenticationToken.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapAuthenticationToken.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.tuleap_oauth;
+
+import hudson.security.SecurityRealm;
+import io.jenkins.plugins.tuleap_oauth.model.UserInfoRepresentation;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.providers.AbstractAuthenticationToken;
+
+import java.io.Serializable;
+
+public class TuleapAuthenticationToken extends AbstractAuthenticationToken {
+
+    private static final long serialVersionUID = 1L;
+    private transient final UserInfoRepresentation userInfo;
+
+    public TuleapAuthenticationToken(UserInfoRepresentation userInfo){
+        super(new GrantedAuthority[] {SecurityRealm.AUTHENTICATED_AUTHORITY});
+
+        this.userInfo = userInfo;
+        this.setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return "";
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.userInfo.getUsername();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapUserDetails.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapUserDetails.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.tuleap_oauth;
+
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.userdetails.User;
+import org.acegisecurity.userdetails.UserDetails;
+
+public class TuleapUserDetails extends User implements UserDetails {
+
+    private String username;
+
+    public TuleapUserDetails(String username, GrantedAuthority[] authorities) {
+        super(username, "", true, true, true, true, authorities);
+        this.username = username;
+    }
+
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return this.username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object rhs) {
+        return super.equals(rhs);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoChecker.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoChecker.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.tuleap_oauth.checks;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.jenkins.plugins.tuleap_oauth.model.UserInfoRepresentation;
+import okhttp3.Response;
+
+public interface UserInfoChecker {
+    boolean checkHandshake(Response response);
+    boolean checkUserInfoResponseHeader(Response response);
+    boolean checkUserInfoResponseBody(UserInfoRepresentation userInfoRepresentation, DecodedJWT idToken);
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.tuleap_oauth.checks;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.jenkins.plugins.tuleap_oauth.model.UserInfoRepresentation;
+import okhttp3.Response;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.logging.Logger;
+
+public class UserInfoCheckerImpl implements UserInfoChecker {
+
+    private static final Logger LOGGER = Logger.getLogger(UserInfoChecker.class.getName());
+
+    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json";
+
+    @Override
+    public boolean checkHandshake(Response response) {
+        if (response.handshake() == null) {
+            LOGGER.warning("TLS is not used");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean checkUserInfoResponseHeader(Response response) {
+        String contentType = response.header("Content-type");
+        if (StringUtils.isBlank(contentType)) {
+            LOGGER.warning("There is no content type");
+            return false;
+        }
+
+        if (!contentType.equals(CONTENT_TYPE_HEADER_VALUE)) {
+            LOGGER.warning("Bad content type value");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean checkUserInfoResponseBody(UserInfoRepresentation userInfoRepresentation, DecodedJWT idToken) {
+        if (StringUtils.isBlank(userInfoRepresentation.getSub())) {
+            LOGGER.warning("sub parameter is missing");
+            return false;
+        }
+
+        if (!userInfoRepresentation.getSub().equals(idToken.getSubject())) {
+            LOGGER.warning("Subject not expected");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
@@ -11,7 +11,7 @@ public class UserInfoCheckerImpl implements UserInfoChecker {
 
     private static final Logger LOGGER = Logger.getLogger(UserInfoChecker.class.getName());
 
-    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json";
+    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json;charset=utf-8";
 
     @Override
     public boolean checkHandshake(Response response) {

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/guice/TuleapOAuth2GuiceModule.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/guice/TuleapOAuth2GuiceModule.java
@@ -17,6 +17,7 @@ public class TuleapOAuth2GuiceModule extends AbstractModule {
         bind(AccessTokenChecker.class).to(AccessTokenCheckerImpl.class);
         bind(PKCECodeBuilder.class).to(PKCECodeBuilderImpl.class);
         bind(JWTChecker.class).to(JWTCheckerImpl.class);
+        bind(UserInfoChecker.class).to(UserInfoCheckerImpl.class);
         bind(OkHttpClient.class).toProvider(OkHttpClientProvider.class).asEagerSingleton();
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/model/UserInfoRepresentation.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/model/UserInfoRepresentation.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.tuleap_oauth.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class UserInfoRepresentation {
+
+    @SerializedName("sub")
+    private String sub;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("preferred_username")
+    private String username;
+
+    @SerializedName("profile")
+    private String profileUrl;
+
+    @SerializedName("picture")
+    private String picture;
+
+    @SerializedName("zoneinfo")
+    private String zoneInfo;
+
+    @SerializedName("locale")
+    private String locale;
+
+    public String getSub() {
+        return sub;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public String getZoneInfo() {
+        return zoneInfo;
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
@@ -51,7 +51,7 @@ public class UserInfoCheckerImplTest {
     @Test
     public void testItReturnsTrueWhenGoodContentType() {
         Response response = mock(Response.class);
-        when(response.header("Content-type")).thenReturn("application/json");
+        when(response.header("Content-type")).thenReturn("application/json;charset=utf-8");
 
         UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
         assertTrue(userInfoChecker.checkUserInfoResponseHeader(response));

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
@@ -1,0 +1,95 @@
+package io.jenkins.plugins.tuleap_oauth.checks;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.jenkins.plugins.tuleap_oauth.model.UserInfoRepresentation;
+import okhttp3.Handshake;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UserInfoCheckerImplTest {
+
+    @Test
+    public void testItReturnsFalseIfTheConnectionDoesNotUseTLS() {
+        Response response = mock(Response.class);
+        when(response.handshake()).thenReturn(null);
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkHandshake(response));
+    }
+
+    @Test
+    public void testItReturnsTrueIfTheConnectionUsesTLS() {
+        Response response = mock(Response.class);
+        Handshake handshake = mock(Handshake.class);
+        when(response.handshake()).thenReturn(handshake);
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertTrue(userInfoChecker.checkHandshake(response));
+    }
+
+    @Test
+    public void testItReturnsFalseWhenTheContentTypeIsMissing() {
+        Response response = mock(Response.class);
+        when(response.header("Content-type")).thenReturn(null);
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkUserInfoResponseHeader(response));
+    }
+
+    @Test
+    public void testItReturnsFalseWhenTheContentTypeValueIsNotExpected() {
+        Response response = mock(Response.class);
+        when(response.header("Content-type")).thenReturn("multipart/form-data; boundary=something");
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkUserInfoResponseHeader(response));
+    }
+
+    @Test
+    public void testItReturnsTrueWhenGoodContentType() {
+        Response response = mock(Response.class);
+        when(response.header("Content-type")).thenReturn("application/json");
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertTrue(userInfoChecker.checkUserInfoResponseHeader(response));
+    }
+
+    @Test
+    public void testItReturnFalseWhenTheSubjectParameterIsMissing() {
+        UserInfoRepresentation userInfoRepresentation = mock(UserInfoRepresentation.class);
+        when(userInfoRepresentation.getSub()).thenReturn(null);
+
+        DecodedJWT idToken = mock(DecodedJWT.class);
+        verify(idToken, never()).getSignature();
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkUserInfoResponseBody(userInfoRepresentation, idToken));
+    }
+
+    @Test
+    public void testItReturnFalseWhenTheSubjectValueIsNotExpected() {
+        UserInfoRepresentation userInfoRepresentation = mock(UserInfoRepresentation.class);
+        when(userInfoRepresentation.getSub()).thenReturn("123");
+
+        DecodedJWT idToken = mock(DecodedJWT.class);
+        when(idToken.getSubject()).thenReturn("1510");
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkUserInfoResponseBody(userInfoRepresentation, idToken));
+    }
+
+    @Test
+    public void testItReturnTrueIfTheBodyIsOk() {
+        UserInfoRepresentation userInfoRepresentation = mock(UserInfoRepresentation.class);
+        when(userInfoRepresentation.getSub()).thenReturn("123");
+
+        DecodedJWT idToken = mock(DecodedJWT.class);
+        when(idToken.getSubject()).thenReturn("123");
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertTrue(userInfoChecker.checkUserInfoResponseBody(userInfoRepresentation, idToken));
+    }
+}


### PR DESCRIPTION
This is a part of [story #14018](https://tuleap.net/plugins/tracker/?aid=14018) have a central management of users and groups using oauth

Now, when you are logged, you should see the Tuleap username of the user used to login in Tuleap.
At the first login of the user in Jenkins, the user will be automaticaly created.
The user information are retrieved thanks to the /userinfo endpoint and access token.